### PR TITLE
[투두] 전체적인 투두 정렬을 변경

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ^3.10
+          python-version: 3.11.9
 
       - name: Install poetry
         run: |

--- a/app/api/controllers/todos.py
+++ b/app/api/controllers/todos.py
@@ -137,14 +137,6 @@ def get_todo_list(
     end_date: date | None = None,
     todo_dao: TodoDAO = Depends(get_todo_dao),
 ):
-    if start_date and not end_date:
-        end_date = datetime.now(timezone("Asia/Seoul")).date()
-
-    if end_date and not start_date:
-        start_date = (
-            datetime.now(timezone("Asia/Seoul")) - timedelta(days=30)
-        ).date
-
     todo_list = todo_dao.get_todo_list(
         completed=completed,
         limit=limit,

--- a/app/api/dao/todo_dao.py
+++ b/app/api/dao/todo_dao.py
@@ -119,22 +119,19 @@ class TodoDAO(ProtectedBaseDAO):
         else:
             query = query.filter(Todo.completed_at.is_(None))
 
-        if start_date and end_date:
-            query = query.filter(
-                and_(
-                    func.date(Todo.target_date) >= start_date,
-                    func.date(Todo.target_date) <= end_date,
-                )
+        if start_date:
+            query = query.filter(func.date(Todo.target_date) >= start_date)
+        if end_date:
+            query = query.filter(func.date(Todo.target_date) <= end_date)
+
+        if completed:
+            query = query.order_by(desc(Todo.completed_at))
+        else:
+            query = query.order_by(
+                asc(Todo.target_date), asc(Todo.order), desc(Todo.updated_at)
             )
 
-        todo = (
-            query.order_by(desc(Todo.target_date), asc(Todo.order))
-            .limit(limit)
-            .offset(offset)
-            .all()
-        )
-
-        return todo
+        return query.limit(limit).offset(offset).all()
 
     def get_todo_list_by_date(
         self,

--- a/app/api/dao/todo_dao.py
+++ b/app/api/dao/todo_dao.py
@@ -151,9 +151,8 @@ class TodoDAO(ProtectedBaseDAO):
             )
             .order_by(
                 nullsfirst(desc(Todo.completed_at)),
-                desc(Todo.target_date),
+                asc(Todo.target_date),
                 desc(Todo.updated_at),
-                desc(Todo.completed_at),
             )
             .all()
         )

--- a/tests/api/endpoints/protected/task/test_task.py
+++ b/tests/api/endpoints/protected/task/test_task.py
@@ -124,11 +124,17 @@ def test_get_uncompleted_todo_task(
     assert len(todo_list) == 6
 
     assert todo_list[0]["target_date"].startswith(
-        target_date.strftime("%Y-%m-%d")
+        previous_target_date.strftime("%Y-%m-%d")
     )
     assert todo_list[0]["completed_at"] is None
 
-    assert todo_list[2]["target_date"].startswith(
-        previous_target_date.strftime("%Y-%m-%d")
-    )
-    assert todo_list[2]["completed_at"] is None
+    for idx in [1, 2]:
+        assert todo_list[idx]["target_date"].startswith(
+            target_date.strftime("%Y-%m-%d")
+        )
+        assert todo_list[idx]["completed_at"] is None
+
+    for todo in todo_list[3:]:
+        assert todo["completed_at"] is not None
+        if isinstance(todo["completed_at"], str):
+            assert todo["completed_at"].strip() != ""

--- a/tests/api/endpoints/protected/todos/conftest.py
+++ b/tests/api/endpoints/protected/todos/conftest.py
@@ -161,7 +161,7 @@ def todo_list_with_date() -> List[Todo]:
             title="Test title 9",
             content="Test content 9",
             order=9,
-            completed_at=datetime(2024, 11, 16, 0, 0, 0),
+            completed_at=datetime(2024, 11, 17, 0, 0, 0),
             updated_at=datetime(2024, 11, 17, 0, 0, 0),
             target_date=datetime(2024, 11, 17, 0, 0, 0),
             user_id=1,

--- a/tests/api/endpoints/protected/todos/test_todos.py
+++ b/tests/api/endpoints/protected/todos/test_todos.py
@@ -164,9 +164,9 @@ def test_get_todo_list__valid_page_and_offset__1_page(
     response_data = response.json()
 
     assert len(response_data) == 3
-    assert response_data[0].get("id") == 7
-    assert response_data[1].get("id") == 6
-    assert response_data[2].get("id") == 5
+    assert response_data[0].get("id") == 1
+    assert response_data[1].get("id") == 2
+    assert response_data[2].get("id") == 3
 
 
 def test_get_todo_list__valid_page_and_offset__2_page(
@@ -189,8 +189,8 @@ def test_get_todo_list__valid_page_and_offset__2_page(
 
     assert len(response_data) == 3
     assert response_data[0].get("id") == 4
-    assert response_data[1].get("id") == 3
-    assert response_data[2].get("id") == 2
+    assert response_data[1].get("id") == 5
+    assert response_data[2].get("id") == 6
 
 
 def test_get_todo_list__valid_date_range(
@@ -219,9 +219,9 @@ def test_get_todo_list__valid_date_range(
     response_data = response.json()
 
     assert len(response_data) == 3
-    assert response_data[0].get("id") == 3
+    assert response_data[0].get("id") == 1
     assert response_data[1].get("id") == 2
-    assert response_data[2].get("id") == 1
+    assert response_data[2].get("id") == 3
 
 
 def test_get_todo_list__complete(
@@ -233,9 +233,7 @@ def test_get_todo_list__complete(
     params = dict(limit=3, offset=0, completed=True)
 
     response = client.get(
-        "/todos",
-        params=params,
-        headers=access_token_headers,
+        "/todos", params=params, headers=access_token_headers
     )
 
     assert response.status_code == 200


### PR DESCRIPTION
- 완료한 투두의 경우는 완료한 날을 기준으로 내림차순 정렬
- 미완료 투두의 경우(task api 포함) target_date를 기준으로 이전 것부터 정렬하도록 변경
   - 미완료 투두를 먼저 보여야 할 것 같아서..