### PR TITLE
회원가입 시 비밀번호에 특수문자도 가능하도록 수정

### DIFF
--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -10,6 +10,9 @@ from app.api.errors import (
 )
 from app.schemas.user import UserData
 
+USERNAME_PATTERN = r"^[A-Za-z0-9]+$"
+PASSWORD_PATTERN = r"^.+$"
+
 
 class SignupInput(BaseModel):
     username: str
@@ -30,7 +33,7 @@ class SignupInput(BaseModel):
             raise ValueError(VALUE_TOO_SHORT)
         elif len(v) > 20:
             raise ValueError(VALUE_TOO_LONG)
-        elif not re.match("^[A-Za-z][A-Za-z0-9]*$", v):
+        elif not re.match(USERNAME_PATTERN, v):
             raise ValueError(VALUE_MUST_BE_ALPHANUM)
         return v
 
@@ -40,7 +43,7 @@ class SignupInput(BaseModel):
             raise ValueError(VALUE_TOO_SHORT)
         elif len(v) > 20:
             raise ValueError(VALUE_TOO_LONG)
-        elif not re.match("^[A-Za-z][A-Za-z0-9]*$", v):
+        elif not re.match(PASSWORD_PATTERN, v):
             raise ValueError(VALUE_MUST_BE_ALPHANUM)
         return v
 

--- a/tests/api/endpoints/auth/test_auth.py
+++ b/tests/api/endpoints/auth/test_auth.py
@@ -28,6 +28,60 @@ def test_signup(client: TestClient, session: Session, user_data: UserBase):
     assert user.nickname == data.nickname
 
 
+def test_signup_starting_with_number(client: TestClient, session: Session):
+    data = SignupInput(
+        username="123user",
+        password="123P@ss!",
+        password_confirm="123P@ss!",
+        email="number.start@example.com",
+        nickname="123닉네임",
+    )
+
+    response = client.post("/auth/signup", json=data.dict())
+
+    assert response.status_code == 201
+
+    user = session.query(User).filter_by(username=data.username).first()
+
+    assert user.username == data.username
+    assert user.email == data.email
+    assert user.nickname == data.nickname
+
+
+def test_signup_with_special_password(client: TestClient, session: Session):
+    data = SignupInput(
+        username="testuser",
+        password="P@ssw0rd!",
+        password_confirm="P@ssw0rd!",
+        email="special.chars@example.com",
+        nickname="닉네임_!@#$%",
+    )
+
+    response = client.post("/auth/signup", json=data.dict())
+
+    assert response.status_code == 201
+
+    user = session.query(User).filter_by(username=data.username).first()
+
+    assert user.username == data.username
+    assert user.email == data.email
+    assert user.nickname == data.nickname
+
+
+def test_signup_with_special_character_in_username_fails(client: TestClient):
+    data = dict(
+        username="test!user",
+        password="password123",
+        password_confirm="password123",
+        email="test.special@example.com",
+        nickname="테스트유저",
+    )
+
+    response = client.post("/auth/signup", json=data)
+
+    assert response.status_code == 422
+
+
 def test_login(client: TestClient, user_data: UserBase, add_user: User):
     data = dict(
         username=add_user.username,


### PR DESCRIPTION
Fix #160 

- 이번에 유저 피드백 중 가입 시 특수문자 기입이 안된다는 의견을 많이 주셔서 우선순위를 높여서 수정했습니다
- 이젠 비밀번호는 길이를 제외하고 제한이 없습니다