### PR TITLE
VScode 테스트 시 .env.dev 파일을 사용하도록 설정 수정

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "python.envFile": "${workspaceFolder}/.env",
+    "python.envFile": "${workspaceFolder}/.env.dev",
     "editor.codeActionsOnSave": {
         "source.organizeImports": "explicit"
     },


### PR DESCRIPTION
- .env와 .env.dev 파일이 존재할 때 테스트용 env 파일은 .env.dev가 더 적절한 것 같아서 수정합니다.